### PR TITLE
Use spark.default.parallelism to calculate default number of partitions

### DIFF
--- a/R4ML/R/r4ml.frame.R
+++ b/R4ML/R/r4ml.frame.R
@@ -72,31 +72,6 @@ setMethod("is.r4ml.numeric",
   }
 )
 
-r4ml.calc.num.partitions <- function(object_size) {
-  logSource <- "calc num partitions"
-
-  # attempt to detect the # of CPU cores on machine
-  cores <- parallel::detectCores(all.tests = TRUE)
-  
-  if (is.null(cores) | cores < 1) {
-    r4ml.warn(logSource, "unable to detect number of CPU cores")
-    cores <- 8 # default to 8 cores
-  }
-
-  num_partitions <- as.numeric(object_size) / r4ml.env$MIN_PARTITION_SIZE
-  num_partitions <- ceiling(num_partitions)
-  
-  if (num_partitions < cores) {
-    # we should have at least as many partitions as cpu cores
-    num_partitions <- cores
-  }
-  
-  r4ml.info(logSource, paste(num_partitions, "partitions"))
-  
-  return(num_partitions)
-}
-
-
 #' Coerce to an R4ML Frame
 #'
 #' Convert a data.frame, r4ml.matrix, or Spark DataFrame into an r4ml.frame
@@ -165,7 +140,7 @@ setMethod("as.r4ml.frame",
     if (repartition) {
 
       if (is.na(numPartitions)) {
-        numPartitions <- r4ml.calc.num.partitions(object_size)
+        numPartitions <- SparkR::sparkR.callJMethod(sysmlSparkContext, "defaultParallelism")
       }
 
       r4ml.info(logSource,


### PR DESCRIPTION
Issue #44 

We should use the Spark variable `spark.default.parallelism` instead of our custom function `r4ml.calc.num.partitions()` to calculate the number of partitions when converting a `data.frame` to `r4ml.frame`

From the [Spark documentation](https://spark.apache.org/docs/latest/configuration.html#execution-behavior):
>For distributed shuffle operations like reduceByKey and join, the largest number of partitions in a parent RDD. For operations like parallelize with no parent RDDs, it depends on the cluster manager:
>- Local mode: number of cores on the local machine
>- Mesos fine grained mode: 8
>- Others: total number of cores on all executor nodes or 2, whichever is larger

